### PR TITLE
ログイン機能の実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
 
   <body>
     <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,0 +1,33 @@
+<% flash.each do |flash_type, message| %>
+  <% flash_styles = case flash_type.to_s
+     when 'notice'
+       { bg: 'bg-blue-50', border: 'border-blue-500', text: 'text-blue-800', icon_color: 'text-blue-400' }
+     when 'alert', 'error'
+       { bg: 'bg-red-50', border: 'border-red-500', text: 'text-red-800', icon_color: 'text-red-400' }
+     when 'warning'
+       { bg: 'bg-yellow-50', border: 'border-yellow-500', text: 'text-yellow-800', icon_color: 'text-yellow-400' }
+     when 'success'
+       { bg: 'bg-green-50', border: 'border-green-500', text: 'text-green-800', icon_color: 'text-green-400' }
+     else
+       { bg: 'bg-gray-50', border: 'border-gray-500', text: 'text-gray-800', icon_color: 'text-gray-400' }
+     end %>
+
+  <div class="rounded-md <%= flash_styles[:bg] %> p-4 mb-6 border-l-4 <%= flash_styles[:border] %>">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <svg class="h-5 w-5 <%= flash_styles[:icon_color] %>" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <% if flash_type.to_s == 'notice' || flash_type.to_s == 'success' %>
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+          <% else %>
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+          <% end %>
+        </svg>
+      </div>
+      <div class="ml-3">
+        <div class="text-sm <%= flash_styles[:text] %>">
+          <%= message %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,71 @@
-<h2>Log in</h2>
+<div class="min-h-screen flex flex-col">
+  <%= render "shared/header/guest_header" %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <main class="flex-grow flex flex-col items-center px-4 py-8">
+    <h1 class="text-2xl font-bold text-center text-black mb-10">ログイン</h1>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+    <%= form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { class: "w-full max-w-md space-y-8" }) do |f| %>
+      <!-- フラッシュメッセージ -->
+      <%= render "shared/flash_messages" %>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <div class="space-y-6">
+        <!-- メールアドレス入力欄 -->
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-semibold text-gray-800" %>
+          <%= f.email_field :email, class: "w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-lg focus:ring-2 focus:ring-blue-400 focus:outline-none" %>
+        </div>
+
+        <!-- パスワード入力欄 -->
+        <div class="relative">
+          <%= f.label :password, "パスワード", class: "block text-sm font-semibold text-gray-800" %>
+          <div data-controller="password-visibility">
+            <%= f.password_field :password,
+                class: "password-field w-full px-4 pr-12 py-2 mt-2 text-gray-700 bg-white border rounded-lg focus:ring-2 focus:ring-blue-400 focus:outline-none",
+                data: { password_visibility_target: "field" } %>
+            <button type="button"
+                    class="toggle-password absolute top-[2.5rem] right-3 flex items-center text-gray-600"
+                    data-action="click->password-visibility#toggle"
+                    aria-label="パスワードを表示">
+              <svg class="show-password hidden"
+                   data-password-visibility-target="showIcon"
+                   xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path d="M9 3.75C4.22727 3.75 1.5 9 1.5 9C1.5 9 4.22727 14.25 9 14.25C13.7727 14.25 16.5 9 16.5 9C16.5 9 13.7727 3.75 9 3.75Z" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M9 11.25C10.2426 11.25 11.25 10.2426 11.25 9C11.25 7.75736 10.2426 6.75 9 6.75C7.75736 6.75 6.75 7.75736 6.75 9C6.75 10.2426 7.75736 11.25 9 11.25Z" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg class="hide-password"
+                   data-password-visibility-target="hideIcon"
+                   xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path d="M15 11.1251C15.9811 9.9988 16.5 9 16.5 9C16.5 9 13.7727 3.75 9 3.75C8.74408 3.75 8.49405 3.76509 8.25 3.79366C7.99334 3.82371 7.7433 3.86866 7.5 3.92664M9 6.75C9.26298 6.75 9.51542 6.79512 9.75 6.87803C10.3893 7.10399 10.896 7.61069 11.122 8.25C11.2049 8.48458 11.25 8.73702 11.25 9M2.25 2.25L15.75 15.75M9 11.25C8.73702 11.25 8.48458 11.2049 8.25 11.122C7.61069 10.896 7.10399 10.3893 6.87803 9.75C6.8354 9.62939 6.80276 9.50406 6.78111 9.375M3.11026 6.75C2.87907 7.00838 2.67176 7.26181 2.48898 7.5C1.83965 8.34618 1.5 9 1.5 9C1.5 9 4.22727 14.25 9 14.25C9.25592 14.25 9.50595 14.2349 9.75 14.2063" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center">
+            <%= f.check_box :remember_me, class: "h-4 w-4 text-blue-600 border-gray-300 rounded" %>
+            <%= f.label :remember_me, "ログイン状態を保持する", class: "ml-2 block text-sm text-gray-800" %>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- ログインボタン -->
+      <div class="pt-12 flex justify-center">
+        <%= f.submit "ログイン", class: "w-[240px] bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full focus:ring-2 focus:ring-blue-400 focus:outline-none transition duration-200" %>
+      </div>
+    <% end %>
+
+    <!-- 新規登録リンク -->
+    <div class="mt-8 text-center">
+      <p class="text-sm text-gray-600">
+        アカウントをお持ちでない方は
+        <a href="/users/sign_up" class="text-blue-500 hover:text-blue-700 transition duration-200">新規会員登録</a>
+      </p>
+      <div class="mt-2">
+        <%= link_to "パスワードを忘れた場合はこちら", new_password_path(resource_name), class: "text-blue-500 hover:text-blue-700 text-sm" %>
+      </div>
     </div>
-  <% end %>
+  </main>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+  <%= render "shared/footer/guest_footer" %>
+</div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,19 @@
+# config/locales/devise.ja.yml
+ja:
+  devise:
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+      already_signed_out: "既にログアウトしています。"
+      user:
+        invalid: "メールアドレスまたはパスワードが正しくありません。"
+        not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
+        unconfirmed: "メールアドレスの確認が必要です。メールをご確認ください。"
+    failure:
+      invalid: "メールアドレスまたはパスワードが正しくありません。"
+      not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
+      unauthenticated: "続行するにはログインまたはアカウント登録が必要です。"
+      unconfirmed: "メールアドレスの確認が必要です。"
+      locked: "アカウントはロックされています。"
+      last_attempt: "あと1回失敗するとアカウントがロックされます。"
+      timeout: "セッションがタイムアウトしました。続行するには再度ログインしてください。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
   # 認証に関連する複数のルートを自動的に生成します。
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-    confirmations: 'users/confirmations'
+    confirmations: 'users/confirmations',
+    sessions: 'users/sessions',
   }
 
   # プロフィール登録機能を実装するためのルーティング


### PR DESCRIPTION
## 概要  
本PRでは、ユーザーがメールアドレスとパスワードでログインできる機能を実装しました。また、ユーザビリティ向上のため、UIの改善も行っています。さらに、Stimulus を使用したパスワードの表示・非表示切り替え機能を実装し、スムーズなユーザー体験を提供します。  

## 内容  

- **ログイン機能の実装**  
  - `devise` を使用し、メールアドレスとパスワードによるログイン処理を実装しました。  

- **ログイン画面の改善**  
  - 「パスワードを忘れた場合」のリンクを追加し、パスワードリセット画面へ遷移できるようにしました。  
  - 「新規会員登録」のリンクを追加し、未登録ユーザーがスムーズにサインアップできるようにしました。  

- **Stimulus を使用したパスワードの表示・非表示切り替え機能**  
  - Stimulus Controller を作成し、ログイン画面のパスワード入力欄に適用しました。  
  - クリック時にボタンにアニメーション効果を追加 し、視覚的なフィードバックを提供しました。  
  - aria-label を適切に設定 し、アクセシビリティを考慮しました。  
- **フラッシュメッセージの表示**  
  - ログイン成功時・失敗時にフラッシュメッセージを表示する処理を追加しました。  
  - フラッシュメッセージを見やすくするため、デザインの調整も行いました。  

## 動作確認  

- 正しいメールアドレス・パスワードでログインできることを確認済み。  
- 間違った情報でログインしようとした場合にエラーメッセージが表示されることを確認済み。  
- 「パスワードを忘れた場合」のリンクからパスワードリセットページに遷移できることを確認済み。  
- 「新規会員登録」のリンクから登録ページへ遷移できることを確認済み。  
- Stimulus によるパスワード表示・非表示切り替えが正常に動作することを確認済み。  
- フラッシュメッセージが適切なタイミングで表示・非表示になることを確認済み。  

## 関連Issue
closes #38 
closes #39 