### PR TITLE
新着投稿一覧

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,9 +1,31 @@
 class PostsController < ApplicationController
-  # 新規投稿フォーム
-  def new
-    @prefectures = Prefecture.all
+  def index
+    @posts = Post.includes(:prefecture).order(created_at: :desc)
+  end
 
-    # デバッグ用：取得した都道府県の数を確認
-    puts "取得した都道府県の数: #{@prefectures.count}"
+  # 「新しい投稿を作成」ボタンを押したときに実行される
+  def new
+    # 「新しい投稿（Post）を作る準備」 をしている
+    @post = Post.new
+    # 「都道府県のリストを全部取り出す」 ためのコード
+    @prefectures = Prefecture.all
+  end
+
+  def create
+    @post = Post.new(post_params)
+    if @post.save
+      flash[:notice] = "投稿が作成されました"
+      redirect_to posts_path
+    else
+      @prefectures = Prefecture.all
+      flash.now[:notice] = "投稿の作成に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:prefecture_id, :content)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+  # 投稿は 1つの都道府県 にひもづく
+  belongs_to :prefecture
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,4 +1,6 @@
 class Prefecture < ApplicationRecord
+  # 都道府県は たくさんの投稿 を持てる
+  has_many :posts
   # バリデーション
   validates :name, presence: true, uniqueness: true
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,19 +1,18 @@
-<form class="p-4 min-h-screen flex flex-col">
+<%= form_with model: @post, class: "p-4 min-h-screen flex flex-col" do |form| %>
   <!-- 都道府県選択フォーム -->
-  <div class="mb-6">
-    <label for="prefecture" class="block text-sm font-medium text-gray-700 mb-2">都道府県を選択</label>
-    <select id="prefecture" name="prefecture" class="block w-full pl-3 pr-10 py-3 text-base border border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md text-gray-400" onchange="this.classList.remove('text-gray-400')">
-      <option value="" disabled selected>都道府県を選択してください</option>
-      <% if @prefectures.present? %>
-        <% @prefectures.each do |prefecture| %>
-          <option value="<%= prefecture.id %>"><%= prefecture.name %></option>
-        <% end %>
-      <% end %>
-    </select>
+  <div class="mb-6 mt-6">
+    <p class="block text-sm font-medium text-gray-700 mb-2">都道府県選択</p>
+    <%= form.collection_select :prefecture_id,
+                              @prefectures,
+                              :id,
+                              :name,
+                              { prompt: "都道府県を選択してください" }, 
+                              { class: "block w-full pl-3 pr-10 py-3 text-base border border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md text-gray-400",
+                                onchange: "this.classList.remove('text-gray-400')" } %>
   </div>
 
   <!-- 写真選択 -->
-  <div class="mb-6">
+  <!--<div class="mb-6">
     <p class="block text-sm font-medium text-gray-700 mb-2">写真を選択</p>
     <a href="#" class="hover:border-blue-500  hover:border-solid hover:text-blue-500 group w-full flex flex-col items-center justify-center rounded-md border-2 border-dashed border-slate-300 text-sm leading-6 text-gray-400 font-medium py-3">
       <svg class="group-hover:text-blue-500 mb-1 text-slate-400" width="20" height="20" fill="currentColor" aria-hidden="true">
@@ -21,17 +20,17 @@
        </svg>
       <p>クリックして写真を選択しよう！</p>
     </a>
-  </div>
+  </div> -->
 
-  <!-- 投稿内容 -->
+  <!-- 投稿内容・ハッシュタグのインラインタグ機能 -->
   <div class="mb-6">
     <p class="block text-sm font-medium text-gray-700 mb-2">投稿内容</p>
-    <textarea class="resize-none w-full border border-gray-300 rounded-md p-2 pb-[200px] placeholder-gray-400 hover:border-blue-500" placeholder="投稿内容を入力してください"></textarea>
+    <%= form.text_area :content, class: "resize-none w-full border border-gray-300 rounded-md p-2 pb-[300px] placeholder-gray-400 hover:border-blue-500", placeholder: "投稿内容を入力してください" %>
   </div>
 
-  <!-- ハッシュタグ -->
-  <div>
-    <p class="block text-sm font-medium text-gray-700 mb-2">ハッシュタグ</p>
-    <input type="text" class="w-full p-2 border border-gray-300 rounded-md hover:border-blue-500 " placeholder="#ハッシュタグを入力してください">
+  <!-- 投稿ボタン -->
+  <div class="flex justify-center">
+    <%= form.submit '投稿する',
+        class: 'w-[240px] bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-full transition duration-150 ease-in-out transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2' %>
   </div>
-</form>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,16 @@
+<div>
+  <% if @posts.present? %>
+    <% @posts.each do |post| %>
+      <div>
+        <div>
+          <p class ="font-bold text-red-400"><%= post.prefecture.name %></p>
+        </div>
+      </div>
+      <div>
+        <%= post.content %>
+      </div>
+    <% end %>
+  <% else %>
+    <div class="mb-3">投稿がありません</div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   # プロフィール登録機能を実装するためのルーティング
   resources :profiles, only: [:new, :create, :edit, :update]
   # 投稿関連
-  resources :posts, only: [:new]
+  resources :posts, only: [:index, :new, :create]
 
   # letter_opener_webのルーティング（開発環境のみ）
   if Rails.env.development?

--- a/db/migrate/20250315145318_add_profile_image_url_to_profiles.rb
+++ b/db/migrate/20250315145318_add_profile_image_url_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddProfileImageUrlToProfiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :profiles, :profile_image_url, :string
+  end
+end

--- a/db/migrate/20250316010356_create_posts.rb
+++ b/db/migrate/20250316010356_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.references :profile, foreign_key: true
+      t.references :prefecture, foreign_key: true
+      t.text :content
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_10_065127) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_16_010356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "profile_id"
+    t.bigint "prefecture_id"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prefecture_id"], name: "index_posts_on_prefecture_id"
+    t.index ["profile_id"], name: "index_posts_on_profile_id"
+  end
 
   create_table "prefectures", force: :cascade do |t|
     t.string "name", null: false
@@ -27,6 +37,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_10_065127) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "profile_image_url"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
@@ -47,5 +58,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_10_065127) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "prefectures"
+  add_foreign_key "posts", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 何をしたのか

新着投稿一覧の表示をさせる実装をしました。（バックエンド側の実装と必要最低限のビュー実装）
- postモデルとpostsテーブルの作成。
- postsコントローラーとルーティングの :index : createを追加。
- postモデルとprefectureモデルの関連性の紐付け。アソシエーションを追加。
- form_withを使ったフォーム作成。
- 新着投稿一覧の表示。（`order(created_at: :desc)`で新着順にしました。）

## なぜしたのか

前回までは投稿フォームの型だけを作っていましたが、今回は投稿作成をしてデータを保存し新着投稿一覧に表示させるまでの実装ができていなかったからです。

## スクリーンショット
**投稿作成画面**
[![Image from Gyazo](https://i.gyazo.com/62ecafa7aa3bf9ae01fe19736a2b078c.png)](https://gyazo.com/62ecafa7aa3bf9ae01fe19736a2b078c)

**新着投稿一覧**
[![Image from Gyazo](https://i.gyazo.com/467a9ba7f15c8fc9ebd4a463cda8c1bc.png)](https://gyazo.com/467a9ba7f15c8fc9ebd4a463cda8c1bc)

## チェックリスト

- [ ]  動作確認をした
- [ ]  新着順になっていること
- [ ]  作成されたデータから、正しく表示されているか

## 学んだこと・メモ
- アソシエーションの関連性について理解できた。
- form_withを使用した実装方法を理解した。
- Railsの命名規則を学んだ。

## 関連Issue

closes #24 