### PR TITLE
ランキングページ

### DIFF
--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,0 +1,4 @@
+class RankingsController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/rankings_helper.rb
+++ b/app/helpers/rankings_helper.rb
@@ -1,0 +1,2 @@
+module RankingsHelper
+end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -38,6 +38,6 @@
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
     <%= form.submit '投稿する',
-        class: 'w-[240px] bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-full transition duration-150 ease-in-out transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2' %>
+        class: "w-[240px] bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-full transition duration-150 ease-in-out transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" %>
   </div>
 <% end %>

--- a/app/views/rankings/index.html.erb
+++ b/app/views/rankings/index.html.erb
@@ -1,0 +1,61 @@
+<!-- app/views/rankings/index.html.erb -->
+<div class="flex flex-col min-h-screen bg-white">
+  <!-- ヘッダー -->
+  <%= render "shared/header/login_header" %>
+
+  <!-- メインコンテンツ -->
+  <main class="flex-1 p-4 flex flex-col">
+    <!-- キャッチフレーズ -->
+    <div class="text-2xl font-bold text-center mb-10">
+      都道府県の魅力を発掘中！
+    </div>
+
+    <!-- 投稿募集メッセージ -->
+    <div class="text-xl text-center font-bold mb-4">
+      現在、皆様からの投稿を募集中です！
+    </div>
+
+    <div class="text-center text-gray-700 mb-10">
+      投稿が集まり次第、都道府県魅力度ランキングを公開します。<br>
+      お楽しみに！
+    </div>
+
+    <!-- 投稿ボタン -->
+    <div class="flex justify-center">
+      <%= link_to "投稿しよう！", new_post_path, class: "w-[240px] bg-blue-600 hover:bg-blue-700 text-white text-center font-bold py-3 px-4 rounded-full transition duration-150 ease-in-out transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2" %>
+    </div>
+
+    <!-- サブメッセージ -->
+    <div class="mt-6 text-center">
+      <p class="mb-4 font-bold">写真と一緒に投稿して</p>
+      <p class="font-bold mb-10">ランキングを盛り上げよう！</p>
+    </div>
+
+    <!-- 説明テキスト（オプション） -->
+    <div class="text-gray-600 text-sm mt-4 px-2 text-center">
+      <p class="mb-2">「ココじゃ」は、みんなの視点で都道府県の魅力を共有するサービスです。</p>
+      <p class="mb-2">地元の人だけが知る穴場スポット、素敵なグルメ、感動した景色など、あなたの発見を投稿してください。</p>
+      <p>投稿された内容をもとに、リアルな魅力度ランキングを作成します！</p>
+    </div>
+  </main>
+
+  <!-- フッター -->
+  <nav class="bg-white w-full flex justify-around items-center p-3 border-t">
+    <a href="<%= posts_path %>" class="flex flex-col items-center justify-center text-gray-500">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-home"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      <span class="text-xs">ホーム</span>
+    </a>
+    <a href="<%= rankings_index_path %>" class="flex flex-col items-center justify-center text-blue-500">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bar-chart"><line x1="12" x2="12" y1="20" y2="10"/><line x1="18" x2="18" y1="20" y2="4"/><line x1="6" x2="6" y1="20" y2="16"/></svg>
+      <span class="text-xs">ランキング</span>
+    </a>
+    <a href="<%= new_post_path %>" class="flex flex-col items-center justify-center text-gray-500">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-plus-square"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M8 12h8"/><path d="M12 8v8"/></svg>
+      <span class="text-xs">投稿作成</span>
+    </a>
+    <a href="#" class="flex flex-col items-center justify-center text-gray-500">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+      <span class="text-xs">マイページ</span>
+    </a>
+  </nav>
+</div>

--- a/app/views/shared/footer/_login_footer.html.erb
+++ b/app/views/shared/footer/_login_footer.html.erb
@@ -8,7 +8,7 @@
         <% end %>
       </li>
       <li class="w-1/4 text-center">
-        <%= link_to class: "flex flex-col items-center justify-center" do %>
+        <%= link_to rankings_index_path class: "flex flex-col items-center justify-center" do %>
           <%= image_tag "ranking.svg", class: "h-6 w-6 mx-auto", alt: "ランキング" %>
           <span class="text-xs mt-1">ランキング</span>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  # ランキング
+  get 'rankings/index'
   # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/test/controllers/rankings_controller_test.rb
+++ b/test/controllers/rankings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class RankingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get rankings_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 何をしたのか

ランキングページは投稿を促すページにしました。

## なぜしたのか

MVPリリース時は投稿がほとんどなく、ランキングが機能しないため。

## チェックリスト

- [ ]  投稿作成のボタンを押したら投稿作成画面へ遷移する
- [ ] フッターのランキングボタンを押したらランキングページに遷移する

## 学んだこと・メモ

`docker-compose exec web rails g controller Rankings index`コマンドを実行することで、ルーティング、コントローラ、ビューが作成される。

## 関連Issue

closes #27