### PR TITLE
オートログイン機能追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     top_page_login_url(protocol: 'https')
   end
+
+  private
+
+  def redirect_if_authenticated
+    if user_signed_in?
+      redirect_to top_page_login_path
+    end
+  end
 end

--- a/app/controllers/static_pages_guest_controller.rb
+++ b/app/controllers/static_pages_guest_controller.rb
@@ -1,4 +1,7 @@
 class StaticPagesGuestController < ApplicationController
+  before_action :redirect_if_authenticated, only: [:top]
+
   def top
+    # 既存のアクション内容
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,9 +10,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    super do |resource|
+      if resource.persisted?
+        sign_in(resource)
+        # プロフィール設定ページへリダイレクト
+        redirect_to profile_setup_path and return
+      end
+    end
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,11 @@ class Users::SessionsController < Devise::SessionsController
     end
   end
 
-  # protected
+  protected
+
+  def after_sign_in_path_for(resource)
+    top_page_login_path
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params


### PR DESCRIPTION
## 💡 何をしたのか

- `ApplicationController` に `redirect_if_authenticated` を追加
- `StaticPagesGuestController` にて、ログイン済みユーザーのルートアクセス時に `top_page_login_path` へリダイレクトするように設定
- `Users::SessionsController` にログイン後の遷移先として `top_page_login_path` を指定

## 🔍 なぜしたのか

- ログイン済みユーザーがゲスト向けトップページへアクセスできないようにするため
- よりスムーズなユーザー体験を提供するために、ログイン状態を保持して自動リダイレクトする仕様に変更

## ✅ チェックリスト

- [x] ログイン状態でルートパス（`/`）へアクセス → `top_page_login_path` にリダイレクトされるか確認
- [x] ログアウト後にルートパスへアクセス → 通常のゲストトップページが表示されるか確認
- [x] ログイン後に `top_page_login_path` へ正常に遷移されるか確認

## 📚 学んだこと・メモ

- `before_action` を使ってコントローラーレベルでのアクセス制御を実装する方法
- Deviseの `after_sign_in_path_for` をオーバーライドしてリダイレクト先をカスタマイズする方法

## 🔗 関連Issue

closes #102 
