### PR TITLE
オートコンプリート検索機能の追加

### DIFF
--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -1,5 +1,4 @@
 # 都道府県（Prefecture）に関する操作を担当するコントローラー
-# 都道府県ごとの投稿一覧や統計情報を提供します
 class PrefecturesController < ApplicationController
   def show
     @prefecture = Prefecture.find(params[:id])
@@ -12,5 +11,48 @@ class PrefecturesController < ApplicationController
 
     @posts_count = @posts.length
     @total_points = @prefecture.posts.joins(:votes).sum('votes.points')
+  end
+
+  # 都道府県に関連する投稿の一覧表示
+  def posts
+    # 都道府県を取得
+    @prefecture = Prefecture.find(params[:id])
+
+    # 都道府県に紐づく投稿を新しい順に取得
+    @posts = @prefecture.posts
+                       .includes(:user, :hashtags, :post_images)
+                       .order(created_at: :desc)
+                       .page(params[:page])
+                       .per(10)
+
+    # 投稿総数の取得
+    @posts_count = @prefecture.posts.count
+
+    # タイトル設定
+    @page_title = "#{@prefecture.name}の投稿"
+
+    # レスポンス形式に応じた処理
+    respond_to do |format|
+      format.html do
+        # HTML形式の場合、統計情報を取得
+        @total_points = @prefecture.posts.left_joins(:votes).sum('COALESCE(votes.points, 0)')
+      end
+
+      # JSON形式のレスポンス（無限スクロール用）
+      format.json do
+        render json: {
+          posts: @posts.as_json(
+            include: [
+              { user: { methods: :profile_image_url } },
+              { post_images: { methods: [:image] } },
+              :hashtags, 
+              :prefecture
+            ],
+            methods: :created_at_formatted
+          ),
+          next_page: @posts.next_page
+        }
+      end
+    end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,32 @@
+class SearchController < ApplicationController
+  # 検索候補を返すAPIエンドポイント
+  def autocomplete
+    # パラメータから検索キーワードを取得
+    query = params[:query].to_s.strip.downcase
+
+    # 空の検索の場合は空の結果を返す
+    if query.blank?
+      render json: { results: [] }
+      return
+    end
+
+    # 検索対象のモデルから該当するデータを取得
+    # 例: ユーザー、都道府県、ハッシュタグから検索
+    users = User.where("username LIKE ? OR uid LIKE ?", "%#{query}%", "%#{query}%")
+                .limit(5)
+                .map { |u| { id: u.id, text: u.username, type: 'user', image: u.profile_image_url.url, url: user_path(u) } }
+
+    prefectures = Prefecture.where("name LIKE ?", "%#{query}%")
+                          .limit(5)
+                          .map { |p| { id: p.id, text: p.name, type: 'prefecture', url: posts_prefecture_path(p) } }
+
+    hashtags = Hashtag.where("name LIKE ?", "%#{query}%")
+                    .limit(5)
+                    .map { |h| { id: h.id, text: h.name, type: 'hashtag', url: hashtag_posts_path(h.name) } }
+
+    # 結果を結合して返す
+    results = users + prefectures + hashtags
+
+    render json: { results: results }
+  end
+end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,188 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input", "results"];
+
+  // 接続時の初期設定
+  connect() {
+    // 検索結果を隠しておく
+    this.hideResults();
+
+    // デバウンスを設定（入力後少し待ってから検索を実行）
+    this.debounceTimeout = null;
+
+    // クリック処理のリスナーを設定
+    this.clickOutsideHandler = this.handleClickOutside.bind(this);
+    document.addEventListener("click", this.clickOutsideHandler);
+
+    console.log("Autocomplete controller connected");
+  }
+
+  // コントローラーが切断されるときの処理
+  disconnect() {
+    // イベントリスナーをクリーンアップ
+    document.removeEventListener("click", this.clickOutsideHandler);
+  }
+
+  // 入力イベントハンドラ
+  search() {
+    // 前回の検索タイマーをクリア
+    clearTimeout(this.debounceTimeout);
+
+    // 検索テキストを取得
+    const query = this.inputTarget.value.trim();
+
+    // 検索テキストが空なら結果を隠す
+    if (query === "") {
+      this.hideResults();
+      return;
+    }
+
+    // 0.3秒後に検索を実行（タイピング中の過剰リクエストを防ぐ）
+    this.debounceTimeout = setTimeout(() => {
+      this.fetchResults(query);
+    }, 300);
+  }
+
+  // APIからデータを取得
+  async fetchResults(query) {
+    try {
+      // APIリクエスト
+      const response = await fetch(
+        `/search/autocomplete?query=${encodeURIComponent(query)}`
+      );
+
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+
+      const data = await response.json();
+
+      // 結果があれば表示
+      if (data.results.length > 0) {
+        this.displayResults(data.results, query);
+      } else {
+        this.showNoResults();
+      }
+    } catch (error) {
+      console.error("検索中にエラーが発生しました:", error);
+      this.showError();
+    }
+  }
+
+  // 検索結果を表示
+  displayResults(results, query) {
+    // 一旦結果をクリア
+    this.resultsTarget.innerHTML = "";
+
+    // 結果のHTMLを生成
+    results.forEach((result) => {
+      // 元のURLを保持
+      let resultUrl = result.url;
+
+      // 都道府県の場合、検索クエリを追加
+      if (result.type === "prefecture") {
+        // URLにクエリパラメータがすでにある場合は&で連結、なければ?で始める
+        const separator = resultUrl.includes("?") ? "&" : "?";
+        resultUrl = `${resultUrl}${separator}query=${encodeURIComponent(
+          query
+        )}`;
+      }
+
+      const item = document.createElement("a");
+      item.href = resultUrl;
+      item.className =
+        "flex items-center p-3 border-b border-gray-100 hover:bg-gray-50 transition";
+
+      let iconHtml = "";
+
+      // 結果タイプごとに異なるアイコンを表示
+      switch (result.type) {
+        case "user":
+          iconHtml = result.image
+            ? `<img src="${result.image}" alt="${result.text}" class="w-8 h-8 rounded-full mr-3 object-cover">`
+            : `<div class="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center mr-3">
+                <svg class="w-4 h-4 text-blue-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd" />
+                </svg>
+              </div>`;
+          break;
+        case "prefecture":
+          iconHtml = `<div class="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center mr-3">
+                        <svg class="w-4 h-4 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                          <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+                        </svg>
+                      </div>`;
+          break;
+        case "hashtag":
+          iconHtml = `<div class="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center mr-3">
+                        <svg class="w-4 h-4 text-purple-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                          <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 010-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd" />
+                        </svg>
+                      </div>`;
+          break;
+      }
+
+      // タイプごとのラベルテキスト
+      const typeText =
+        result.type === "user"
+          ? "ユーザー"
+          : result.type === "prefecture"
+          ? "都道府県"
+          : result.type === "hashtag"
+          ? "ハッシュタグ"
+          : "";
+
+      item.innerHTML = `
+        ${iconHtml}
+        <div class="flex-1">
+          <div class="font-medium">${result.text}</div>
+          <div class="text-xs text-gray-500">${typeText}</div>
+        </div>
+      `;
+
+      this.resultsTarget.appendChild(item);
+    });
+
+    // 結果を表示
+    this.showResults();
+  }
+
+  // 結果がない場合の表示
+  showNoResults() {
+    this.resultsTarget.innerHTML = `
+      <div class="p-4 text-center text-gray-500">
+        検索結果がありません
+      </div>
+    `;
+    this.showResults();
+  }
+
+  // エラー表示
+  showError() {
+    this.resultsTarget.innerHTML = `
+      <div class="p-4 text-center text-red-500">
+        検索中にエラーが発生しました
+      </div>
+    `;
+    this.showResults();
+  }
+
+  // 検索結果を表示
+  showResults() {
+    this.resultsTarget.classList.remove("hidden");
+  }
+
+  // 検索結果を隠す
+  hideResults() {
+    this.resultsTarget.classList.add("hidden");
+  }
+
+  // コンポーネント外クリック時のハンドラ
+  handleClickOutside(event) {
+    // クリックがコンポーネントの外部で発生した場合、結果を隠す
+    if (!this.element.contains(event.target)) {
+      this.hideResults();
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -28,3 +28,6 @@ application.register("vote", VoteController);
 
 import InfiniteScrollController from "./infinite_scroll_controller";
 application.register("infinite-scroll", InfiniteScrollController);
+
+import AutocompleteController from "./autocomplete_controller";
+application.register("autocomplete", AutocompleteController);

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,7 +30,7 @@ class Post < ApplicationRecord
 
   # JSON応答用に日付をフォーマットするメソッド
   def created_at_formatted
-    created_at.strftime('%Y年%m月%d日')
+    I18n.l(created_at, format: :long) if created_at
   end
 
   private

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,7 @@
 <!-- app/views/posts/show.html.erb -->
 <div class="mx-auto min-h-screen pb-16 bg-gray-50">
-  <%= render "shared/header/setting_header" %>
+  <%= render "shared/header/login_header" %>
+
   <div class="container mx-auto px-4 py-8 md:pl-[calc(288px+2rem)] md:pr-8">
     <div class="bg-white rounded-lg shadow-sm overflow-hidden">
       <!-- 投稿のヘッダー部分 -->

--- a/app/views/prefectures/posts.html.erb
+++ b/app/views/prefectures/posts.html.erb
@@ -1,0 +1,146 @@
+<div class="mx-auto min-h-screen pb-16 bg-gray-50">
+  <%= render "shared/header/login_header" %>
+
+  <div class="max-w-4xl mx-auto px-4 md:pl-[calc(288px+2rem)] md:pr-8">
+    <!-- ヘッダー部分 -->
+    <div class="py-4 mb-4">
+      <div class="flex items-center">
+        <div class="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center mr-3">
+          <svg class="w-5 h-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+          </svg>
+        </div>
+        <div>
+          <h1 class="text-xl font-bold"><%= @prefecture.name %>の投稿一覧</h1>
+          <p class="text-sm text-gray-600">
+            全投稿: <%= @posts_count %>件
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- 投稿リスト -->
+    <% if @posts.present? %>
+      <div class="space-y-6 mb-6">
+        <% @posts.each do |post| %>
+          <div class="bg-white rounded-lg shadow-sm overflow-hidden">
+            <!-- ユーザーヘッダー -->
+            <div class="flex items-center justify-between p-4 border-b border-gray-100">
+              <%= link_to user_path(post.user), class: "flex items-center gap-4 hover:opacity-75 transition-opacity" do %>
+                <div class="w-10 h-10 rounded-full bg-gray-100 flex-shrink-0 overflow-hidden">
+                  <% if post.user.profile_image_url.present? %>
+                    <%= image_tag post.user.profile_image_url.url, alt: post.user.uid, class: "w-full h-full object-cover" %>
+                  <% else %>
+                    <%= image_tag "sample_icon1.svg", alt: post.user.uid, class: "w-full h-full object-cover" %>
+                  <% end %>
+                </div>
+                <div>
+                  <h4 class="font-semibold text-sm"><%= post.user.uid %></h4>
+                  <p class="text-xs text-gray-500"><%= post.prefecture.name %></p>
+                </div>
+              <% end %>
+            </div>
+
+            <!-- 画像表示（画像があれば） -->
+            <% if post.post_images.present? %>
+              <div class="relative" data-controller="slider">
+                <div class="w-full md:aspect-[4/3] aspect-square overflow-hidden touch-none">
+                  <div class="flex h-full will-change-transform touch-pan-y" data-slider-target="wrapper">
+                    <% post.post_images.each_with_index do |post_image, index| %>
+                      <div class="w-full flex-shrink-0 flex items-center justify-center select-none" data-slider-target="slide">
+                        <% if post_image.image.present? && post_image.image.url.present? %>
+                          <% if index == 0 %>
+                            <%= image_tag post_image.image.url, class: "w-full h-full object-contain select-none pointer-events-none", draggable: "false" %>
+                          <% else %>
+                            <img data-src="<%= post_image.image.url %>" class="w-full h-full object-contain select-none pointer-events-none lazy-image" draggable="false">
+                          <% end %>
+                        <% else %>
+                          <div class="w-full h-full bg-gray-900 flex items-center justify-center text-white select-none">
+                            <span>画像なし</span>
+                          </div>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+
+                  <!-- インジケーター（複数画像の場合） -->
+                  <% if post.post_images.length > 1 %>
+                    <div class="absolute top-2 right-2 bg-black bg-opacity-50 text-white text-xs px-2 py-1 rounded-full">
+                      <span data-slider-target="counter">1</span>/<%= post.post_images.length %>
+                    </div>
+
+                    <!-- ナビゲーションボタン -->
+                    <button class="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black bg-opacity-20 rounded-full shadow flex items-center justify-center z-10 focus:outline-none" data-slider-target="prevButton" data-action="click->slider#prev">
+                      <svg class="w-8 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                      </svg>
+                    </button>
+                    <button class="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black bg-opacity-20 rounded-full shadow flex items-center justify-center z-10 focus:outline-none" data-slider-target="nextButton" data-action="click->slider#next">
+                      <svg class="w-8 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                      </svg>
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+
+            <!-- 投稿本文 -->
+            <div class="px-4 py-4">
+              <div class="text-sm md:text-base mb-2">
+                <span><%= format_content_with_hashtags(post.content) %></span>
+              </div>
+
+              <% if post.hashtags.present? %>
+                <div class="flex flex-wrap gap-2 mt-3">
+                  <% post.hashtags.each do |tag| %>
+                    <%= link_to "/posts/hashtag/#{tag.name}", class: "text-xs bg-blue-50 text-blue-600 px-2 py-1 rounded-full" do %>
+                      #<%= tag.name %>
+                    <% end %>
+                  <% end %>
+                </div>
+              <% end %>
+
+              <p class="text-xs md:text-sm text-gray-500 mt-4">投稿日：<%= l post.created_at, format: :long %></p>
+            </div>
+
+            <!-- 詳細ページへのリンク -->
+            <div class="p-4 border-t">
+              <%= link_to post_path(post),
+                        class: "w-full inline-flex items-center justify-center px-4 py-2 rounded-lg bg-indigo-600 text-white font-medium hover:bg-indigo-700 transition duration-150 ease-in-out shadow-sm hover:shadow focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 text-sm" do %>
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+                </svg>
+                ポイントをつけよう！
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- ページネーション -->
+      <div class="my-8 flex justify-center">
+        <%= paginate @posts %>
+      </div>
+    <% else %>
+      <div class="bg-white rounded-lg shadow-sm p-8 text-center">
+        <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+        </svg>
+        <p class="text-gray-500 mb-4">
+          <%= @prefecture.name %>の投稿はまだありません
+        </p>
+        <% if user_signed_in? %>
+          <%= link_to new_post_path(prefecture_id: @prefecture.id), class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition inline-block" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+            最初の投稿を作成する
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render "shared/footer/login_footer" %>
+</div>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,0 +1,25 @@
+<div class="relative" data-controller="autocomplete">
+  <div class="relative">
+    <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-500">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+    </span>
+    <%= text_field_tag :search,
+      nil,
+      placeholder: "ユーザー、地域、ハッシュタグを検索",
+      class: "w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500",
+      data: {
+        autocomplete_target: "input",
+        action: "input->autocomplete#search"
+      }
+    %>
+  </div>
+
+  <!-- 検索結果のドロップダウン -->
+  <div
+    class="absolute z-50 mt-1 w-full bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden hidden"
+    data-autocomplete-target="results">
+    <!-- ここに結果が動的に表示されます -->
+  </div>
+</div>

--- a/app/views/shared/header/_login_header.html.erb
+++ b/app/views/shared/header/_login_header.html.erb
@@ -5,6 +5,9 @@
       <%= image_tag "cocoja_logo.svg", class: "h-[4rem] w-auto" %>
     </div>
   </nav>
+  <div class="px-4 sm:px-6 lg:px-8 py-2">
+    <%= render 'shared/search_form' %>
+  </div>
 </header>
 
 <%# PC用サイドバー %>
@@ -34,6 +37,10 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
         <span>マイページ</span>
       <% end %>
+    </div>
+
+    <div class="py-2">
+      <%= render 'shared/search_form' %>
     </div>
 
     <%# 設定リンク %>

--- a/app/views/shared/header/_mypage_header.html.erb
+++ b/app/views/shared/header/_mypage_header.html.erb
@@ -10,6 +10,9 @@
       </div>
     </div>
   </div>
+  <div class="px-4 sm:px-6 lg:px-8 py-2">
+    <%= render 'shared/search_form' %>
+  </div>
 </header>
 
 <%# PC用サイドバー %>
@@ -39,6 +42,10 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
         <span>マイページ</span>
       <% end %>
+    </div>
+
+    <div class="py-2">
+      <%= render 'shared/search_form' %>
     </div>
 
     <%# 設定リンク %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
   # ハッシュタグ
   get '/posts/hashtag/:name', to: 'posts#hashtag', as: 'hashtag_posts'
 
+  # 検索API
+  get 'search/autocomplete', to: 'search#autocomplete'
+
   # deviseのルーティング
   devise_for :users, controllers: {
     registrations: 'users/registrations',
@@ -40,7 +43,11 @@ Rails.application.routes.draw do
   end
 
   # 都道府県
-  resources :prefectures, only: %i[index show]
+  resources :prefectures, only: %i[index show] do
+    member do
+      get :posts  # 都道府県ごとの投稿一覧（タイムライン形式）を表示するための新しいルート
+    end
+  end
 
   # ランキング
   resources :rankings, only: [:index]


### PR DESCRIPTION
このPull Requestでは、オートコンプリート検索機能、都道府県別の投稿一覧ページの追加、およびいくつかのUI改善を含む、重要な新機能と機能拡張を導入しています。以下は、主な変更点をテーマ別にまとめたものです。

## 🔧 新機能
- オートコンプリート検索APIエンドポイントを SearchController に追加。ユーザー・都道府県・ハッシュタグの検索候補を提供するためのクエリ処理、結果の整形、JSONレスポンスの生成を行います。
（`app/controllers/search_controller.rb`）

- クライアントサイドでの検索入力と動的な検索候補表示を行うStimulusの**AutocompleteController** を実装。入力のデバウンス処理とリアルタイム更新を対応。
（`app/javascript/controllers/autocomplete_controller.js, index.js`）

- PrefecturesController に posts アクションを追加し、**都道府県ごとの投稿一覧（ページネーション付き）**をHTMLおよびJSON形式で表示可能にしました。
（`app/controllers/prefectures_controller.rb`）

## 🗺️ ルーティングの更新
- オートコンプリート検索API用のルートを追加し、都道府県ごとの投稿取得のために Prefectures に posts メンバールートを追加。
（`config/routes.rb`）

## 🎨 UIの改善
- 複数のヘッダー（login_header, mypage_header）に検索フォームを統合し、オートコンプリート機能に対応。
（`app/views/shared/header/_login_header.html.erb`, `app/views/shared/header/_mypage_header.html.erb`）

- 都道府県別投稿表示用の専用ビューを作成。レスポンシブなレイアウトで、ユーザー情報、投稿画像、ページネーションを表示。
（`app/views/prefectures/posts.html.erb`）

- 投稿詳細ページのビュー（show.html.erb）で使用するヘッダーを login_header に変更。
（`app/views/posts/show.html.erb`）

## 🧩 モデルおよびビューの改善
- Postモデルの created_at_formatted メソッドで I18n.l を使用し、日付のローカライズ表現を改善。
（`app/models/post.rb`）

- オートコンプリート検索の導入に伴い、再利用可能な検索フォームパーシャルを作成。複数ビューでの統一利用が可能に。
（`app/views/shared/_search_form.html.erb`）

これらの変更により、検索機能が強化され、投稿の見つけやすさが向上し、全体的なUIも改善されました。

## チェックリスト

- [x] 動作確認をした
  - 都道府県ページの表示
  - 投稿一覧の表示


## 関連Issue

closes #115 

